### PR TITLE
fix(sidenav): Removes the border radius for active nav items

### DIFF
--- a/src/components/sidenav/sidenavSection/sidenavSection.scss
+++ b/src/components/sidenav/sidenavSection/sidenavSection.scss
@@ -21,6 +21,8 @@
     font-weight: 500;
     color: $color-primary;
     border-left-color: $color-primary;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
 
     md-icon {
       color: $color-primary;
@@ -52,5 +54,7 @@
     font-weight: 500;
     color: $color-primary;
     border-left-color: $color-primary;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
 }


### PR DESCRIPTION
The design for the sidenav has a rectangular bar on the left side of active sidenav items. The border-radius inherited by .md-button rounds it out, and is inconsistent with other implementations of the sidenav within the company.

See: https://unity.slack.com/archives/C50U8SRCZ/p1515608856000447