### PR TITLE
account for nested states

### DIFF
--- a/docs/src/components/sidenav/organizationNav.js
+++ b/docs/src/components/sidenav/organizationNav.js
@@ -18,7 +18,7 @@ class OrganizationNav {
       text: 'organizationNav.foonbar',
       menu: [
         { text: 'organizationNav.foo', sref: 'app.organizationNav.foo' },
-        { text: 'organizationNav.bar', sref: 'app.organizationNav.bar' },
+        { text: 'organizationNav.baz', sref: 'app.organizationNav.bar.baz' },
       ],
     }, {
       icon: 'apps',
@@ -51,6 +51,9 @@ export default angular
     }, {
       name: 'app.organizationNav.bar',
       url: '/bar',
+    }, {
+      name: 'app.organizationNav.bar.baz',
+      url: '/baz',
     }];
 
     states.forEach((state) => {
@@ -65,7 +68,7 @@ export default angular
         organizationNav: {
           foonbar: 'Foo & Bar',
           foo: 'Foo',
-          bar: 'Bar',
+          baz: 'Baz',
           google: 'Google.com',
         },
       })

--- a/src/components/sidenav/sidenavSection/sidenavSection.js
+++ b/src/components/sidenav/sidenavSection/sidenavSection.js
@@ -26,7 +26,7 @@ export default class SidenavSection {
   }
 
   isActiveState(sref) {
-    return this.$state.current.name === sref;
+    return this.$state.includes(sref);
   }
 
   isMenuItemActive(items) {


### PR DESCRIPTION
The sidenav right now does not stay open if the sref link is a parent and the page routed to is a nested state. This PR updates the isActiveState check to account for nested states.